### PR TITLE
Feat/stats csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ All the latter options plus the following in case your application run in a Dock
 
 `--config PATH`                 Path to config file (YAML or JSON) containing the long version of flags from option 1
 
+#### Optional Flags
+
+`--stats-file PATH`             Path where to store the cortisol statistics output as a csv
+
 Here's a YAML example:
 
 ```YAML
@@ -117,6 +121,7 @@ users: 100
 spawn-rate: 30
 run-time: "20m"
 cortisol-file: "some_cortisol_file.py"
+stats-file: "cortisol_stats.csv"
 ```
 
 Here's a YAML example with docker container id:
@@ -129,6 +134,7 @@ spawn-rate: 30
 run-time: "20m"
 cortisol-file: "some_cortisol_file.py"
 container-id: "80f1bc1e7feb"
+stats-file: "cortisol_stats.csv"
 ```
 
 and a JSON example:
@@ -141,6 +147,7 @@ and a JSON example:
   "spawn_rate": 30,
   "run_time": "20m",
   "cortisol_file": "some_cortisol_file.py",
-  "container_id": "80f1bc1e7feb"
+  "container_id": "80f1bc1e7feb",
+  "stats-file": "cortisol_stats.csv"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For detailed reference to Cortisol commands please go to: [Read the Docs](https:
 
 ### Prerequisites
 
-cortisol requires the following one of the following Python versions: 3.8, 3.9, 3.10 or 3.11
+Cortisol requires one of the following Python versions: 3.8, 3.9, 3.10 or 3.11
 
 ### Install cortisol
 

--- a/cortisol/commands/logs.py
+++ b/cortisol/commands/logs.py
@@ -77,6 +77,12 @@ def cost_estimate(
         help="Optional docker container id where your application runs",
     ),
     config: Path = typer.Option(None, "--config", help="Path to config file"),
+    stats_file: Path = typer.Option(
+        None,
+        "-s",
+        "--stats-file",
+        help="Optional stats file path where the stats will be stored as csv",
+    ),
 ):
     """
     Forecast log costs pre-production with Cortisol for Datadog, New Relic, and Grafana
@@ -103,6 +109,7 @@ def cost_estimate(
             spawn_rate = data["spawn-rate"]
             run_time = data["run-time"]
             container_id = data.get("container-id", "")
+            stats_file = data.get("stats-file", None)
         except (FileNotFoundError, ValueError, KeyError) as e:
             typer.echo(str(e))
             raise typer.Abort()
@@ -119,6 +126,7 @@ def cost_estimate(
         spawn_rate=spawn_rate,
         run_time=run_time,
         container_id=container_id,
+        stats_file=stats_file,
     )
 
 

--- a/cortisol/cortisollib/hooks.py
+++ b/cortisol/cortisollib/hooks.py
@@ -1,3 +1,4 @@
+import csv
 from time import time
 from prettytable import PrettyTable
 
@@ -142,6 +143,15 @@ def on_quit(environment, **kwargs):
     # Create a PrettyTable instance
     table = create_results_table(obs_stats)
     print(table)
+    if obs_stats["stats_file"]:
+        with open(obs_stats["stats_file"], "w") as f:
+            header = ["run_id", "n_requests"] + list(obs_stats["logs"].keys())
+            values = [f"cortisol_{int(time())}", obs_stats["n_requests"]] + list(
+                obs_stats["logs"].values()
+            )
+            w = csv.writer(f, delimiter=",")
+            w.writerow(header)
+            w.writerow(values)
     return table
 
 
@@ -237,6 +247,7 @@ def on_request(
         },
     )
     stats.setdefault("n_requests", 0)
+    stats.setdefault("stats_file", context["stats_file"])
 
     log_file = context["log_file"]
     container_id = context["container_id"]

--- a/cortisol/cortisollib/hooks.py
+++ b/cortisol/cortisollib/hooks.py
@@ -1,4 +1,5 @@
 import csv
+import uuid
 from time import time
 from prettytable import PrettyTable
 
@@ -145,8 +146,10 @@ def on_quit(environment, **kwargs):
     print(table)
     if obs_stats["stats_file"]:
         with open(obs_stats["stats_file"], "w") as f:
-            header = ["run_id", "n_requests"] + list(obs_stats["logs"].keys())
-            values = [f"cortisol_{int(time())}", obs_stats["n_requests"]] + list(
+            header = ["run_id", "timestamp", "n_requests"] + list(
+                obs_stats["logs"].keys()
+            )
+            values = [uuid.uuid1(), int(time()), obs_stats["n_requests"]] + list(
                 obs_stats["logs"].values()
             )
             w = csv.writer(f, delimiter=",")

--- a/cortisol/cortisollib/log_cost_estimator.py
+++ b/cortisol/cortisollib/log_cost_estimator.py
@@ -93,6 +93,7 @@ def render_locust_command(
     spawn_rate: int,
     run_time: str,
     container_id: str,
+    stats_file: Path = None,
 ):
     """
     Generate a command for running a Locust load test in headless mode.
@@ -107,6 +108,7 @@ def render_locust_command(
         spawn_rate (int): The rate at which new users are spawned per second.
         run_time (str): The duration of the load test run (e.g., '10m' for 10 minutes).
         container_id (str): Identifier for the Docker container, if applicable.
+        stats_file (Path): Optional. File path where the cortisol stats will be stored as csv
 
     Returns:
         List[str]: A list representing the command for running the Locust load test.
@@ -140,6 +142,9 @@ def render_locust_command(
         log_file,
     ]
 
+    if stats_file:
+        command += ["--stats-file", stats_file]
+
     return command
 
 
@@ -151,6 +156,7 @@ def get_cost_estimate(
     spawn_rate: int,
     run_time: str,
     container_id: str = "",
+    stats_file: Path = None,
 ):
     """
     Calculate the estimated cost of logs.
@@ -168,6 +174,7 @@ def get_cost_estimate(
         spawn_rate (int): The rate at which new users are spawned per second.
         run_time (str): The duration of the load test run (e.g., '10m' for 10 minutes).
         container_id (str): Identifier for the Docker container, if applicable.
+        stats_file (Path): Optional. File path where the cortisol stats will be stored as csv
 
     Returns:
         int: The return code of the subprocess that executed the Locust load test.
@@ -185,7 +192,7 @@ def get_cost_estimate(
     render_locustfile(cortisol_file)
 
     command = render_locust_command(
-        host, log_file, num_users, spawn_rate, run_time, container_id
+        host, log_file, num_users, spawn_rate, run_time, container_id, stats_file
     )
 
     done = threading.Event()

--- a/cortisol/cortisollib/templates/cli_loadtest.py.j2
+++ b/cortisol/cortisollib/templates/cli_loadtest.py.j2
@@ -1,4 +1,5 @@
 from time import time
+from pathlib import Path
 from locust.env import Environment
 from locust import task, events, HttpUser, between
 
@@ -14,6 +15,13 @@ def _(parser):
         type=str,
         env_var="CONTAINER_ID",
         default="1212aa67e530af75b3310e1e5b30261b36844a6748df1d321088c4d48a20ebd0",
+    )
+    parser.add_argument(
+        "--stats-file",
+        type=Path,
+        env_var="STATS_FILE",
+        nargs="?",
+        default=None,
     )
 
 

--- a/cortisol/cortisollib/users.py
+++ b/cortisol/cortisollib/users.py
@@ -74,5 +74,6 @@ class CortisolHttpUser(User):
             "start_time": self.start_time,
             "initial_log_volume": self.initial_log_volume,
             "initial_log_entries": self.initial_log_entries,
+            "stats_file": self.environment.parsed_options.stats_file,
         }
         return default_context

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -47,6 +47,10 @@ All the latter options plus the following in case your application run in a Dock
 
 `--config PATH`                 Path to config file (YAML or JSON) containing the long version of flags from option 1
 
+#### Optional Flags
+
+`--stats-file PATH`             Path where to store the cortisol statistics output as a csv
+
 Here's a YAML example:
 
 ```YAML
@@ -56,6 +60,7 @@ users: 100
 spawn-rate: 30
 run-time: "20m"
 cortisol-file: "some_cortisol_file.py"
+stats-file: "cortisol_stats.csv"
 ```
 
 Here's a YAML example with docker container id:
@@ -68,6 +73,7 @@ spawn-rate: 30
 run-time: "20m"
 cortisol-file: "some_cortisol_file.py"
 container-id: "80f1bc1e7feb"
+stats-file: "cortisol_stats.csv"
 ```
 
 and a JSON example:
@@ -80,6 +86,7 @@ and a JSON example:
   "spawn_rate": 30,
   "run_time": "20m",
   "cortisol_file": "some_cortisol_file.py",
-  "container_id": "80f1bc1e7feb"
+  "container_id": "80f1bc1e7feb",
+  "stats-file": "cortisol_stats.csv"
 }
 ```

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ### Prerequisities
 
-Cortisol requires the following one of the following Python versions: 3.8, 3.9, 3.10 or 3.11
+Cortisol requires one of the following Python versions: 3.8, 3.9, 3.10 or 3.11
 
 ### Install Cortisol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cortisol"
-version = "0.2.2"
+version = "0.3.0"
 description = "Accurately forecast log costs pre-production with Cortisol for Datadog, New Relic, and Grafana 💰📉"
 authors = ["pm3310 <pavlos@cortisol.ai>", "dvarelas <dionysis@cortisol.ai>"]
 license = "Apache License 2.0"


### PR DESCRIPTION
Added optional argument that allows to users to specify a path where cortisol statistics can be written as csv. The file contains a run_id, a timestamp and all the statistics that are currently being displayed by cortisol.